### PR TITLE
Add Gitleaks secret scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,16 @@ jobs:
         run: pnpm exec nx run-many -t lint --skip-nx-cache --output-style=stream
       - name: Build projects
         run: pnpm exec nx run-many -t build --configuration=production --skip-nx-cache --output-style=stream
+
+  secret-scan:
+    name: Scan for secrets with Gitleaks
+    runs-on: ubuntu-latest
+    needs: verify-branch-name
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a dedicated Gitleaks job to the CI workflow to scan pull requests for secrets
- configure checkout to fetch full history so Gitleaks can analyze the repository effectively

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d6a1d26044832f8b25b451e5addeba